### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/antoniosantanair/cd3d25b8-86b3-4212-9d26-c1c3c8c3dfb5/681df90a-b7eb-4f94-90db-09394beccb97/_apis/work/boardbadge/714cdc92-603e-40ef-9bb4-e3d8a572edc3)](https://dev.azure.com/antoniosantanair/cd3d25b8-86b3-4212-9d26-c1c3c8c3dfb5/_boards/board/t/681df90a-b7eb-4f94-90db-09394beccb97/Microsoft.RequirementCategory)
 # CT-0
 
 Checkout the Wiki tab.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/antoniosantanair/cd3d25b8-86b3-4212-9d26-c1c3c8c3dfb5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.